### PR TITLE
Use a dummy device for provider networking

### DIFF
--- a/ansible/infra-up.yaml
+++ b/ansible/infra-up.yaml
@@ -116,28 +116,6 @@
       user_wireguard_ip: "{{ item.value.allowed_ips }}"
     loop: "{{ wireguard_users | dict2items }}"
 
-## Configure provider0 interface on bastion and first host
-- hosts: bastion host-00
-  become: true
-  tasks:
-  - name: Write provider netplan
-    ansible.builtin.template:
-      src: templates/provider.yaml.j2
-      dest: "/etc/netplan/60-provider.yaml"
-    vars:
-      configs:
-        bastion:
-          local_ip: "{{ hostvars['bastion']['internal_ip'] }}"
-          remote_ip: "{{ hostvars['host-00']['ansible_host'] }}"
-          tunnel_ip: "{{ provider_cidr | ansible.utils.nthhost(1) }}/{{ provider_cidr | ansible.utils.ipaddr('prefix') }}"
-        host-00:
-          local_ip: "{{ hostvars['host-00']['ansible_host'] }}"
-          remote_ip: "{{ hostvars['bastion']['internal_ip'] }}"
-          tunnel_ip: "{{ provider_cidr | ansible.utils.nthhost(2) }}/{{ provider_cidr | ansible.utils.ipaddr('prefix') }}"
-  - name: Apply provider netplan
-    ansible.builtin.shell:
-      cmd: netplan apply
-
 - hosts: openstack
   become: true
   vars:

--- a/ansible/openstack-up.yaml
+++ b/ansible/openstack-up.yaml
@@ -57,6 +57,15 @@
       - gcc
       - libssl-dev
       - python3-venv
+      - python3-openstackclient
+    become: true
+
+  - name: Create dummy network device for provider networking
+    ansible.builtin.shell: |
+      if ! ip tuntap list | grep br_ex_port ; then
+          ip tuntap add mode tap br_ex_port
+          ip link set dev br_ex_port up
+      fi
     become: true
 
   - name: Create /etc/kolla directory
@@ -170,3 +179,27 @@
       src: /etc/kolla/clouds.yaml
       dest: /etc/openstack/clouds.yaml
       remote_src: true
+
+  - name: Configure NAT for the host
+    ansible.builtin.shell: |
+      if ! ip a show dev br-ex | grep ${EXT_NET_GATEWAY} ; then
+          ip a add ${EXT_NET_GATEWAY}/255.255.255.0 dev br-ex
+          iptables -t nat -A POSTROUTING -s ${EXT_NET_CIDR} -o eth0 -j MASQUERADE
+          echo 1 > /proc/sys/net/ipv4/ip_forward
+          iptables -A FORWARD -i br-ex -o eth0 -j ACCEPT
+          iptables -A FORWARD -i eth0 -o br-ex -j ACCEPT
+      fi
+    environment:
+      EXT_NET_GATEWAY: "{{ provider_cidr | ansible.utils.nthhost(1) }}"
+      EXT_NET_CIDR: "{{ provider_cidr }}"
+    become: true
+
+  # FIXME: This should only run once. Perhaps we should do this ourselves in Ansible?
+  - name: Run initonce script
+    ansible.builtin.shell: |
+      . /etc/kolla/venv/bin/activate
+      /etc/kolla/venv/share/kolla-ansible/init-runonce
+    environment:
+      EXT_NET_GATEWAY: "{{ provider_cidr | ansible.utils.nthhost(1) }}"
+      EXT_NET_CIDR: "{{ provider_cidr }}"
+      EXT_NET_RANGE: "start={{ provider_cidr | ansible.utils.nthhost(2),end={{ provider_cidr | ansible.utils.nthhost(-2) }}

--- a/ansible/templates/globals.yml.j2
+++ b/ansible/templates/globals.yml.j2
@@ -154,7 +154,7 @@ network_interface: "eth0"
 # though an IP address can exist on this interface, it will be unusable in most
 # configurations. It is recommended this interface not be configured with any IP
 # addresses for that reason.
-neutron_external_interface: "provider0"
+neutron_external_interface: "br_ex_port"
 
 # Valid options are [ openvswitch, ovn, linuxbridge, vmware_nsxv, vmware_nsxv3, vmware_nsxp, vmware_dvs ]
 # if vmware_nsxv3 or vmware_nsxp is selected, enable_openvswitch MUST be set to "no" (default is yes)
@@ -380,7 +380,7 @@ enable_cinder_backend_lvm: "yes"
 #enable_neutron_qos: "no"
 #enable_neutron_agent_ha: "no"
 #enable_neutron_bgp_dragent: "no"
-enable_neutron_provider_networks: "no"
+enable_neutron_provider_networks: "yes"
 #enable_neutron_segments: "no"
 #enable_neutron_sfc: "no"
 #enable_neutron_trunk: "no"


### PR DESCRIPTION
Replace our use of a tunnel with a tap device.

We still need to remove the remnants of the provider tunnel and configure SNAT
on the bastion to forward to host-00 (the controller) directly.
